### PR TITLE
fix: preload記述が間違っていた不具合を修正

### DIFF
--- a/src/pages/policy.tsx
+++ b/src/pages/policy.tsx
@@ -12,7 +12,7 @@ const IndexPage = () => (
       title="個人情報保護方針"
       canonical="/policy/"
       link={[
-        { rel: "preload", href: "/assets/img/ph_top_about.jpg", as: "image" },
+        { rel: "preload", href: "/assets/img/ph_top_policy.jpg", as: "image" },
       ]}
     />
     <CommonHeaderBlock


### PR DESCRIPTION
preloadによるヘッダー画像読み込みの最適化が有効になっていなかったため修正しました