### PR TITLE
事務所の住所表記を変更

### DIFF
--- a/src/components/Organism/CompanySummary.tsx
+++ b/src/components/Organism/CompanySummary.tsx
@@ -24,8 +24,7 @@ const CompanySummary = () => (
       <DefinitionBlock.Body>
         <StyledLine>本社</StyledLine>
         <StyledLine>
-          &#12306;105-0004 東京都港区新橋1-12-9 A-PLACE新橋駅前
-          ビジネスエアポート新橋
+          &#12306;105-0004 東京都港区新橋1-12-9 A-PLACE新橋駅前 7F
         </StyledLine>
       </DefinitionBlock.Body>
     </DefinitionBlock>

--- a/src/components/Organism/Footer.tsx
+++ b/src/components/Organism/Footer.tsx
@@ -155,8 +155,7 @@ const Footer = ({ className }: { className?: string }) => {
           <Logo src="/assets/img/logo_footer.png" alt="ロゴ" />
           <CompanyName>エイミー株式会社</CompanyName>
           <CompanyAddress>
-            &#12306;105-0004 東京都港区新橋1-12-9 A-PLACE新橋駅前
-            ビジネスエアポート新橋
+            &#12306;105-0004 東京都港区新橋1-12-9 A-PLACE新橋駅前 7F
           </CompanyAddress>
         </InfomationContainer>
         <List>

--- a/src/components/Organism/RecruitCareerSummary.tsx
+++ b/src/components/Organism/RecruitCareerSummary.tsx
@@ -20,8 +20,7 @@ const RecruitCareerSummary = () => (
       <DefinitionBlock.Body>
         <StyledLine>本社</StyledLine>
         <StyledLine>
-          &#12306;105-0004 東京都港区新橋1-12-9 A-PLACE新橋駅前
-          ビジネスエアポート新橋
+          &#12306;105-0004 東京都港区新橋1-12-9 A-PLACE新橋駅前 7F
         </StyledLine>
       </DefinitionBlock.Body>
     </DefinitionBlock>

--- a/src/components/Organism/RecruitFreshSummary.tsx
+++ b/src/components/Organism/RecruitFreshSummary.tsx
@@ -18,8 +18,7 @@ const RecruitFreshSummary = () => (
       <DefinitionBlock.Body>
         <StyledLine>本社</StyledLine>
         <StyledLine>
-          &#12306;105-0004 東京都港区新橋1-12-9 A-PLACE新橋駅前
-          ビジネスエアポート新橋
+          &#12306;105-0004 東京都港区新橋1-12-9 A-PLACE新橋駅前 7F
         </StyledLine>
       </DefinitionBlock.Body>
     </DefinitionBlock>


### PR DESCRIPTION
社内協議の結果、事務所の住所表記を変更しました。
変更された箇所は以下の通りです。
- サイト内フッターの左部分
- 会社概要ページの項目「所在地」
- 採用情報ページの新卒採用の項目「勤務地」
- 採用情報ページのキャリア採用の項目「勤務地」