### PR TITLE
採用情報ページにdescriptionを追加した

### DIFF
--- a/src/pages/recruit.tsx
+++ b/src/pages/recruit.tsx
@@ -13,6 +13,7 @@ type RecruitTabState = "pdm" | "se";
 const IndexPage = () => (
   <>
     <Helmet
+      description="日本のモノづくりを応援！！電子工作やハードウェア、IoTの知識の交流が行える『elchika(エルチカ)』を運営している、エイミー株式会社の採用ページです。"
       title="採用情報"
       canonical="/recruit/"
       link={[


### PR DESCRIPTION
社内協議の結果、採用情報ページに以下のdescriptionを追加した。

`日本のモノづくりを応援！！電子工作やハードウェア、IoTの知識の交流が行える『elchika(エルチカ)』を運営している、エイミー株式会社の採用ページです。`